### PR TITLE
Reduce Exports in Character Count

### DIFF
--- a/api/entries.json
+++ b/api/entries.json
@@ -69,6 +69,13 @@
       "concept": "Character Counter",
       "entry": "Implemented the character counter on the concept covered field. Created a few problems with shared variables along the way, which I solved by making them local & unique to the target Id.",
       "id": 10
+    },
+    {
+      "date": "2020-08-12",
+      "mood": "happy",
+      "concept": "Character Counter",
+      "entry": "Asked Steve for tips on how to make the counter more modular. He suggested using module state, which led me to moving the event listener over to the module. Eliminated an export! Easier to use!",
+      "id": 11
     }
   ]
 }

--- a/scripts/characterCounter.js
+++ b/scripts/characterCounter.js
@@ -1,22 +1,36 @@
-export const listenForComposition = (targetID, characterLimit) => {
+const eventHub = document.querySelector(".container")
+let targets = []
 
-  const currentEntryField = document.querySelector(`#${targetID}`)
-  
-  currentEntryField.addEventListener("keyup", compositionEvent => {
-    const currentText = compositionEvent.target.value
-    const charactersUsed = currentText.length
-    updateCharactersRemaining( targetID, characterLimit, charactersUsed )
+eventHub.addEventListener("keyup", compositionEvent => {
+  //check if the composition is on one of the targetIDs
+  //if(compositionEvent.target.id)
+  targets.forEach( target => {
+    if(target.targetID === compositionEvent.target.id) {
+      
+      const currentText = compositionEvent.target.value
+      const charactersUsed = currentText.length
+      updateCharactersRemaining( target.targetID, target.characterLimit, charactersUsed)
+      }
+    })
+  }
+)
+
+export const setupAndRenderCharacterCounter = (targetID, characterLimit) => {
+  targets.push({
+    targetID: targetID,
+    characterLimit: characterLimit
   })
-}
 
-
-export const renderCharactersRemaining = ( targetID, limit, used ) => {
-  return `
-  <div class="character-limit--${targetID}">CharactersRemaining = ${limit - used}/${limit}</div>
-  `
+  return render(targetID, characterLimit, characterLimit)
 }
 
 const updateCharactersRemaining = ( targetID, limit, used ) => {
   const contentTarget = document.querySelector(`.character-limit--${targetID}`)
-  contentTarget.innerHTML = renderCharactersRemaining( targetID, limit, used)
+  contentTarget.innerHTML = render( targetID, limit, used)
+}
+
+const render = ( targetID, limit, used ) => {
+  return `
+  <div class="character-limit--${targetID}">CharactersRemaining = ${limit - used}/${limit}</div>
+  `
 }

--- a/scripts/characterCounter.js
+++ b/scripts/characterCounter.js
@@ -2,8 +2,7 @@ const eventHub = document.querySelector(".container")
 let targets = []
 
 eventHub.addEventListener("keyup", compositionEvent => {
-  //check if the composition is on one of the targetIDs
-  //if(compositionEvent.target.id)
+  
   targets.forEach( target => {
     if(target.targetID === compositionEvent.target.id) {
       

--- a/scripts/journalEntryForm.js
+++ b/scripts/journalEntryForm.js
@@ -1,5 +1,5 @@
 import { saveJournalEntry } from "./journalDataProvider.js"
-import { listenForComposition, renderCharactersRemaining } from "./characterCounter.js"
+import { setupAndRenderCharacterCounter } from "./characterCounter.js"
 
 const contentCharacterLimit = 200
 const conceptCharacterLimit = 20
@@ -36,8 +36,6 @@ eventHub.addEventListener("journalEntryChange", customEvent => {
 
 export const listForm = () => {
   render()
-  listenForComposition("current-entry--content", contentCharacterLimit)
-  listenForComposition("current-entry--conceptCovered", conceptCharacterLimit) 
 }
 
 const render = () => {
@@ -62,14 +60,14 @@ const render = () => {
       <fieldset>
         <label for="conceptCovered">Concept Covered</label>
         <input type="text" name="conceptCovered" id="current-entry--conceptCovered" maxlength=${conceptCharacterLimit}>
-        ${renderCharactersRemaining( "current-entry--conceptCovered", conceptCharacterLimit, conceptCharacterLimit )}
+        ${setupAndRenderCharacterCounter( "current-entry--conceptCovered", conceptCharacterLimit )}
       </fieldset>
     </form>
     <form action="">
       <fieldset>
         <label for="journalEntry">Journal Entry</label>
         <textarea name="journalEntry" rows="4" cols="50" id="current-entry--content" maxlength=${contentCharacterLimit}></textarea>
-        ${renderCharactersRemaining( "current-entry--content", contentCharacterLimit, contentCharacterLimit )}
+        ${setupAndRenderCharacterCounter( "current-entry--content", contentCharacterLimit )}
       </fieldset>
     </form>
     <button type="button" class="current-entry--submitt">Submit Entry</button>


### PR DESCRIPTION
Make the character counter more modular by adding the notion of a module state which contains the id's and character limits for the elements that the character counter is targeting.

1. Verify that both character counters still work.